### PR TITLE
rough way to run a user init script

### DIFF
--- a/remote_user/remote_user_auth.py
+++ b/remote_user/remote_user_auth.py
@@ -97,7 +97,7 @@ class RemoteUserAuthenticator(LocalAuthenticator):
 
         self.add_user(nameduser)
 
-        user_exists = yield gen.maybe_future(self.system_user_exists(user))
+        user_exists = yield gen.maybe_future(self.system_user_exists(nameduser))
         if not user_exists:
             # if we have a user initialisation script, run it now
             if self.postadduser_script:

--- a/remote_user/remote_user_auth.py
+++ b/remote_user/remote_user_auth.py
@@ -66,6 +66,13 @@ class RemoteUserAuthenticator(LocalAuthenticator):
 
         help="""HTTP header to inspect for the authenticated username.""")
 
+    postadduser_script = Unicode(
+    
+        default_value=False,
+
+        config=True
+        
+        help="""Path to script for user initialisation.""")
 
 
     def get_handlers(self, app):
@@ -89,13 +96,9 @@ class RemoteUserAuthenticator(LocalAuthenticator):
         self.add_user(nameduser)
 
         # if we have a user initialisation script, run it now
-        if hasattr(self, 'postadduser_script'):
+        if self.postadduser_script:
             import subprocess
             subprocess.call([self.postadduser_script, nameduser])
 
         return username
-
-
-
-
 

--- a/remote_user/remote_user_auth.py
+++ b/remote_user/remote_user_auth.py
@@ -97,8 +97,8 @@ class RemoteUserAuthenticator(LocalAuthenticator):
 
         self.add_user(nameduser)
 
-        user_exists = yield gen.maybe_future(self.system_user_exists(nameduser))
-        if not user_exists:
+        if not os.path.exists(os.path.join(["/home", nameduser.name, 
+                                            "dds-notebooks"]))
             # if we have a user initialisation script, run it now
             if self.postadduser_script:
                 subprocess.call([self.postadduser_script, nameduser.name])

--- a/remote_user/remote_user_auth.py
+++ b/remote_user/remote_user_auth.py
@@ -98,7 +98,7 @@ class RemoteUserAuthenticator(LocalAuthenticator):
         self.add_user(nameduser)
 
         if not os.path.exists(os.path.join("/home", nameduser.name,
-                                           "dds-notebooks"))
+                                           "dds-notebooks")):
             # if we have a user initialisation script, run it now
             if self.postadduser_script:
                 subprocess.call([self.postadduser_script, nameduser.name])

--- a/remote_user/remote_user_auth.py
+++ b/remote_user/remote_user_auth.py
@@ -68,7 +68,7 @@ class RemoteUserAuthenticator(LocalAuthenticator):
 
     postadduser_script = Unicode(
     
-        default_value=False,
+        default_value='',
 
         config=True,
         

--- a/remote_user/remote_user_auth.py
+++ b/remote_user/remote_user_auth.py
@@ -1,5 +1,7 @@
 import os
 
+import subprocess
+
 from jupyterhub.handlers import BaseHandler
 
 from jupyterhub.auth import Authenticator
@@ -95,10 +97,11 @@ class RemoteUserAuthenticator(LocalAuthenticator):
 
         self.add_user(nameduser)
 
-        # if we have a user initialisation script, run it now
-        if self.postadduser_script:
-            import subprocess
-            subprocess.call([self.postadduser_script, nameduser])
+        user_exists = yield gen.maybe_future(self.system_user_exists(user))
+        if not user_exists:
+            # if we have a user initialisation script, run it now
+            if self.postadduser_script:
+                subprocess.call([self.postadduser_script, nameduser])
 
         return username
 

--- a/remote_user/remote_user_auth.py
+++ b/remote_user/remote_user_auth.py
@@ -88,6 +88,11 @@ class RemoteUserAuthenticator(LocalAuthenticator):
 
         self.add_user(nameduser)
 
+        # if we have a user initialisation script, run it now
+        if hasattr(self, 'postadduser_script'):
+            import subprocess
+            subprocess.call([self.postadduser_script, nameduser])
+
         return username
 
 

--- a/remote_user/remote_user_auth.py
+++ b/remote_user/remote_user_auth.py
@@ -70,7 +70,7 @@ class RemoteUserAuthenticator(LocalAuthenticator):
     
         default_value=False,
 
-        config=True
+        config=True,
         
         help="""Path to script for user initialisation.""")
 

--- a/remote_user/remote_user_auth.py
+++ b/remote_user/remote_user_auth.py
@@ -101,7 +101,7 @@ class RemoteUserAuthenticator(LocalAuthenticator):
         if not user_exists:
             # if we have a user initialisation script, run it now
             if self.postadduser_script:
-                subprocess.call([self.postadduser_script, nameduser])
+                subprocess.call([self.postadduser_script, nameduser.name])
 
         return username
 

--- a/remote_user/remote_user_auth.py
+++ b/remote_user/remote_user_auth.py
@@ -97,8 +97,8 @@ class RemoteUserAuthenticator(LocalAuthenticator):
 
         self.add_user(nameduser)
 
-        if not os.path.exists(os.path.join(["/home", nameduser.name, 
-                                            "dds-notebooks"]))
+        if not os.path.exists(os.path.join("/home", nameduser.name,
+                                           "dds-notebooks"))
             # if we have a user initialisation script, run it now
             if self.postadduser_script:
                 subprocess.call([self.postadduser_script, nameduser.name])


### PR DESCRIPTION
Needed a way to run a script for user initialisation. Thought the right way to do this would be to specify it in the [config file](https://github.com/edinburghlivinglab/livinglab-hubserver/blob/master/llabjupyterhub-remote/jupyterhub_config.py); and do nothing different if not specified. Script will clone in the `dds_notebooks` repo, and set up the users git credentials.

Would be nice to have a cleaner way of doing this though.
